### PR TITLE
better line splitting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 =====
 PyLRC
 =====
+.. image:: https://img.shields.io/pypi/v/pylrc.svg
+.. image:: https://img.shields.io/pypi/dm/pylrc.svg
+.. image:: https://img.shields.io/github/license/doakey3/pylrc.svg
 
 A python library for parsing and converting .lrc files
 

--- a/pylrc/parser.py
+++ b/pylrc/parser.py
@@ -7,7 +7,7 @@ synced_line_regex = re.compile(r'^(\[[0-5]\d:[0-5]\d(\.\d\d)?\])+.*', flags=re.M
 
 
 def parse(lrc):
-    lines = lrc.split('\n')
+    lines = lrc.splitlines()
     lyrics = Lyrics()
     items = []
 


### PR DESCRIPTION
This is important, because I got lrc files where \r\n is used and with `.split("\n")` every line ends with a \r