### PR TITLE
BUGFIX: two digit numbers not correctly displayed

### DIFF
--- a/pylrc/classes.py
+++ b/pylrc/classes.py
@@ -164,7 +164,7 @@ class Lyrics(list):
         for i in self:
             minutes = "%02d" % i.minutes
             seconds = "%02d" % i.seconds
-            milliseconds = ("%02d" % i.milliseconds)[0:2]
+            milliseconds = ("%03d" % i.milliseconds)[0:2]
 
             lrc = ''.join(['[', minutes, ':', seconds, '.', milliseconds, ']'])
             lrc += i.text


### PR DESCRIPTION
milliseconds are usually 3 digit numbers. Noticed that shifts are not working correctly, when the resulting milliseconds are only 2 digit.